### PR TITLE
Move landing page analytics initialization into useEffect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { analytics, trackLandingPageView } from '@/lib/analytics'
 import { LandingHero } from '@/components/landing/landing-hero'
@@ -66,13 +66,15 @@ export default function LandingPage() {
     return <LandingPageFallback />
   }
 
-  // Initialize analytics (no async operations that cause redirects)
-  try {
-    analytics.init()
-    trackLandingPageView()
-  } catch (error) {
-    console.warn('Analytics initialization failed:', error)
-  }
+  useEffect(() => {
+    // Initialize analytics (no async operations that cause redirects)
+    try {
+      analytics.init()
+      trackLandingPageView()
+    } catch (error) {
+      console.warn('Analytics initialization failed:', error)
+    }
+  }, [])
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
## Summary
- re-import useEffect in the landing page
- move analytics initialization into a useEffect to avoid duplicate runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74a7facfc832fa09cf7c36af7b95f